### PR TITLE
Travis-CI PHP8.1 対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: php
+dist: bionic
 php:
   - '7.1'
   - '7.2'
   - '7.3'
   - '7.4'
   - '8.0'
-  - '8.1'
+  - '8.1.0'
 env:
   - laravel=5.8.*
   - laravel=^6.0
@@ -33,11 +34,11 @@ matrix:
       env: laravel=^9.0
     - php: '8.0'
       env: laravel=5.8.*
-    - php: '8.1'
+    - php: '8.1.0'
       env: laravel=5.8.*
-    - php: '8.1'
+    - php: '8.1.0'
       env: laravel=^6.0
-    - php: '8.1'
+    - php: '8.1.0'
       env: laravel=^7.0
 
 cache:


### PR DESCRIPTION
Travis-Ci で laravel 5.8 〜 9.0 まで、PHP7.1〜8.1 までの UnitTest を通すようにする。

1. https://travis-ci.community/t/php-7-4-is-broken-error-while-loading-shared-libraries-libargon2-so-1/12804/14
1. https://travis-ci.community/t/php-8-1-support/12439