### PR TITLE
返り値をちゃんと見る

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,20 +35,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
-          composer update --prefer-dist --no-interaction --no-progress
+          composer update --prefer-dist --no-interaction --no-progress --with="illuminate/support:^${{ matrix.laravel }}"
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit ${{ matrix.laravel >= 10 && '--display-deprecations --fail-on-deprecation' || '' }}

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,13 @@
     "ext-json": "*",
     "ext-zip": "*",
     "guzzlehttp/guzzle": "^6.0|^7.0",
-    "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0"
+    "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/support": "^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",
-    "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+    "phpunit/phpunit": "^9.0|^10.4|^11.5",
     "phpstan/phpstan": "^2.1"
   },
   "autoload": {

--- a/src/ChatworkChannel.php
+++ b/src/ChatworkChannel.php
@@ -32,7 +32,7 @@ class ChatworkChannel
         }
 
         try{
-            $this->client->post('https://api.chatwork.com/v2/rooms/' . $roomId . '/messages', [
+            $response = $this->client->post('https://api.chatwork.com/v2/rooms/' . $roomId . '/messages', [
                 'headers' => [
                     'X-ChatWorkToken' => Config::get('chatwork.token'),
                 ],
@@ -40,7 +40,16 @@ class ChatworkChannel
                     'body' => $chatworkMessage->message(),
                     'self_unread' => $chatworkMessage->selfUnreadStatus,
                 ],
+                'http_errors' => false
             ]);
+
+            if ($response->getStatusCode() === 400) {
+                throw new ChatworkException(
+                    $response->getBody()->getContents(),
+                    $response->getStatusCode(),
+                    (new \Exception)->getPrevious()
+                );
+            }
         } catch (\Throwable $e){
             throw new ChatworkException($e->getMessage(), $e->getCode(), $e->getPrevious());
         }

--- a/src/ChatworkChannel.php
+++ b/src/ChatworkChannel.php
@@ -28,6 +28,8 @@ class ChatworkChannel
         return $this->client->post('https://api.chatwork.com/v2/rooms/' . $roomId . '/messages', [
             'headers' => [
                 'X-ChatWorkToken' => Config::get('chatwork.token'),
+                'accept' => 'application/json',
+                'content-type' => 'application/x-www-form-urlencoded',
             ],
             'form_params' => [
                 'body' => $chatworkMessage->message(),

--- a/src/Exception/AccessTokenInsufficientScopeException.php
+++ b/src/Exception/AccessTokenInsufficientScopeException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace ATYasu\Chatwork\Exception;
+
+class AccessTokenInsufficientScopeException extends HttpException
+{
+
+}

--- a/src/Exception/ChatworkException.php
+++ b/src/Exception/ChatworkException.php
@@ -3,7 +3,8 @@ declare(strict_types=1);
 
 namespace ATYasu\Chatwork\Exception;
 
-class ChatworkException extends \Exception
-{
+use Psr\Http\Message\ResponseInterface;
 
+class ChatworkException extends Exception
+{
 }

--- a/src/Exception/ChatworkTokenLimitException.php
+++ b/src/Exception/ChatworkTokenLimitException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace ATYasu\Chatwork\Exception;
+
+class ChatworkTokenLimitException extends HttpException
+{
+
+}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace ATYasu\Chatwork\Exception;
+
+abstract class Exception extends \Exception
+{
+
+}

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace ATYasu\Chatwork\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+
+class HttpException extends Exception
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct(
+            $response->getBody()->getContents(),
+            $response->getStatusCode(),
+            (new \Exception)->getPrevious()
+        );
+    }
+}

--- a/src/Exception/InvalidAPITokenException.php
+++ b/src/Exception/InvalidAPITokenException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace ATYasu\Chatwork\Exception;
+
+class InvalidAPITokenException extends HttpException
+{
+
+}

--- a/tests/ChatworkChannelTest.php
+++ b/tests/ChatworkChannelTest.php
@@ -89,7 +89,20 @@ class ChatworkChannelTest extends TestCase
         $this->clientMock
             ->shouldReceive('post')
             ->once()
-            ->andThrow(new \Exception());
+            ->andReturnUsing(function ($url, $params){
+                $this->assertEquals('https://api.chatwork.com/v2/rooms/999999/messages', $url);
+                $this->assertEquals('test_token', $params['headers']['X-ChatWorkToken']);
+                $this->assertEquals('test message', $params['form_params']['body']);
+                $this->assertEquals(1, $params['form_params']['self_unread']);
+
+                return new Response(
+                    400,
+                    [
+                        'content-type' => 'application/json'
+                    ],
+                    \json_encode(["errors" => ["Invalid Request"]])
+                );
+            });
 
         $this->expectException(ChatworkException::class);
         $this->target->send($this->mockNotifiable, $this->mockNotification);


### PR DESCRIPTION
Document: https://developer.chatwork.com/reference/post-rooms-room_id-messages

- 200: ok
- 400: Post 内容が変。RunTimeError が良いのかしら。
- 401: 認証エラー
- 403: 投稿権限がないエラー
- 429: API 使いすぎエラー

---

# する事

1. 401, 403, 429 のそれぞれでエラーが起きた時の処理対応を追加する。
2. Post で投げる時、バイト数が 65535 byte 以上の時は例外出す感じにする？切り詰める？

## 429 の時

- x-ratelimit-reset header を見て、投げるタイミングを待つ。1分以上待つような感じだと、例外エラーを出す。


